### PR TITLE
Temporary Race Condition Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Inline styling for HTML mail in golang
 
+SparkLayer fork adds a temporary fix for a race condition when the HTML contains multiple style elements.
+
 # Document
 [![GoDoc](https://godoc.org/github.com/vanng822/go-premailer/premailer?status.svg)](https://godoc.org/github.com/vanng822/go-premailer/premailer)
 [![Go Report Card](https://goreportcard.com/badge/github.com/vanng822/go-premailer)](https://goreportcard.com/report/github.com/vanng822/go-premailer)

--- a/premailer/premailer.go
+++ b/premailer/premailer.go
@@ -2,15 +2,12 @@ package premailer
 
 import (
 	"fmt"
+	"github.com/vanng822/css"
+	"golang.org/x/net/html"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
-
-	"github.com/PuerkitoBio/goquery"
-	"github.com/vanng822/css"
-	"golang.org/x/net/html"
 )
 
 // Premailer is the inteface of Premailer
@@ -105,22 +102,18 @@ func (pr *premailer) sortRules() {
 }
 
 func (pr *premailer) collectRules() {
-	var wg sync.WaitGroup
 	pr.doc.Find("style:not([data-premailer='ignore'])").Each(func(_ int, s *goquery.Selection) {
 		if media, exist := s.Attr("media"); exist && media != "all" {
 			return
 		}
-		wg.Add(1)
 		pr.allRules = append(pr.allRules, nil)
-		go func(ruleSetIndex int) {
-			defer wg.Done()
-			ss := css.Parse(s.Text())
-			pr.allRules[ruleSetIndex] = ss.GetCSSRuleList()
-			s.ReplaceWithHtml("")
-		}(len(pr.allRules) - 1)
-	})
-	wg.Wait()
 
+		for i := range pr.allRules {
+			ss := css.Parse(s.Text())
+			pr.allRules[i] = ss.GetCSSRuleList()
+			s.ReplaceWithHtml("")
+		}
+	})
 }
 
 func (pr *premailer) collectElements() {


### PR DESCRIPTION
This PR is a temporary fix until I can contribute a proper fix to the authors repo.

Currently, when the HTML contains more than one style element, more than one go routine tries to write to a variable at the same time, causing a race condition. I need to spend a bit more time fully understanding how to solve this in concurrency and wait groups. Talking to Tim, channels sounds like the way to go.

